### PR TITLE
fix blockquote styling

### DIFF
--- a/_sass/_06_typography.scss
+++ b/_sass/_06_typography.scss
@@ -211,37 +211,19 @@ article dl dd   { line-height: 1.6; margin-bottom: rem-calc(12); margin-left: re
 ------------------------------------------------------------------- */
 
 blockquote {
-    font-style: italic;
     position: relative;
     border: none;
-    margin: 0 30px 30px 30px;
-    color:  $grey-11;
+    margin: 0;
+    padding: 0 1.5rem;
+    border-left: 4px solid #a1a4b8;
+    .blog .blog-post article & {
+        &, p {
+            font-style: italic;
+        }
+    }
 }
+ 
 
-    blockquote p {font-style: italic; color: $grey-10; }
-
-    blockquote:before {
-        display:block;content:"\00BB";
-        font-size:80px;
-        line-height: 0;
-        position:absolute;
-        left:-25px;
-        top: auto;
-        color: $grey-11;
-    }
-    blockquote:after {
-        display:block;
-        content:"\00AB";
-        font-size:80px;
-        line-height: 0;
-        position:absolute;
-        right:-10px;
-        bottom: 20px;
-        color: $grey-11;
-    }
-    blockquote cite:before {
-        content:"\2014 \0020"
-    }
     blockquote cite a,blockquote cite a:visited {
         color: $grey-10;
     }


### PR DESCRIPTION
# Current:
![image](https://user-images.githubusercontent.com/743976/30626133-cde155ca-9d95-11e7-8256-1ad6c81e8b50.png)

# Updated:

![image](https://user-images.githubusercontent.com/743976/30626150-e7905c96-9d95-11e7-9d19-b13da47fd9bf.png)

Demo:
https://blockquotes--oicr-softeng.netlify.com/francois_gerthoffert/2017/08/23/infrastructure-procurement-in-large-scale-genomic-projects/

